### PR TITLE
fix: reconnect BACnet client after network outage (#18)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,21 +1,10 @@
-# Tests and dev tooling
-tests/
-TESTING.md
-pyproject.toml
-uv.lock
-
-# Release notes
-rl_*
-
-# Virtual BACnet device (test tool, not part of the integration)
-BACnet virtual device/
-
 # Python
 __pycache__/
 *.py[cod]
 *$py.class
 *.egg-info/
 *.egg
+*.so
 dist/
 build/
 .eggs/
@@ -25,24 +14,81 @@ build/
 venv/
 env/
 
-
-# pytest
+# Test / coverage / type-check artifacts
 .pytest_cache/
 .coverage
+.coverage.*
 htmlcov/
+coverage.xml
+.tox/
+.mypy_cache/
+.dmypy.json
+dmypy.json
 
-# IDE
+# Tooling caches
+.ruff_cache/
+
+# uv lock — kept local (near-empty, not used by CI)
+uv.lock
+
+# Local-only reference material (large PDFs, internal notes)
+docs/
+
+# AI tools & agent instruction files (local-only, never ship)
+# Instruction / memory files
+AGENTS.md
+AGENT.md
+CLAUDE.md
+CLAUDE.local.md
+GEMINI.md
+gemini.md
+.cursorrules
+.cursorignore
+# Tool local configs and directories
+.claude/
+.opencode/
+opencode.json
+opencode.jsonc
+.cursor/
+.github/copilot-instructions.md
+.github/copilot/
+.aider
+.aider.*
+.aider/
+.continue/
+.continueconfig
+.codeium*
+.tabnine*
+.gemini/
+.anthropic/
+.openai/
+.gpteng/
+.sourcegraph/
+.sourcery/
+.llm/
+
+# IDE / editors
 .idea/
 .vscode/
 *.swp
 *.swo
 *~
 
-# OS
+# OS junk
 .DS_Store
 Thumbs.db
+desktop.ini
 
-docs/
-.claude
-CLAUDE.md
-.ruff_cache
+# Logs / temp / backups
+*.log
+*.bak
+*.tmp
+*.orig
+
+# Environment / secrets
+.env
+.env.*
+
+# MemPalace per-project files (issue #185)
+mempalace.yaml
+entities.json

--- a/custom_components/bacnet/bacnet_client.py
+++ b/custom_components/bacnet/bacnet_client.py
@@ -112,6 +112,13 @@ class BACnetClient:
         self._cov_tasks: dict[str, asyncio.Task] = {}
         # Per-device RPM support cache: True = supported (or untested), False = rejected
         self._rpm_supported: dict[str, bool] = {}
+        # Last successful connect() parameters — used by reconnect() to
+        # re-register with the BBMD after a network outage (issue #18).
+        # BBMD foreign device registration has a TTL (default 900s); once it
+        # expires during an outage, the BBMD stops forwarding packets to us
+        # until we re-register with the same parameters.
+        self._last_bbmd_address: str | None = None
+        self._last_bbmd_ttl: int = 900
 
     @staticmethod
     def _derive_device_instance(local_ip: str, local_port: int) -> int:
@@ -171,6 +178,11 @@ class BACnetClient:
             bbmd_ttl: Time-to-live for foreign device registration (seconds).
         """
         device_object, local_addr = self._build_app_args()
+
+        # Persist connect parameters so reconnect() can re-register with the
+        # BBMD using identical settings after an outage (issue #18).
+        self._last_bbmd_address = bbmd_address
+        self._last_bbmd_ttl = bbmd_ttl
 
         if bbmd_address:
             _LOGGER.debug(
@@ -273,6 +285,29 @@ class BACnetClient:
                 "UDP transport is None after awaiting tasks — "
                 "network communication will likely fail"
             )
+
+    async def reconnect(self) -> None:
+        """Tear down and re-establish the network connection.
+
+        Reuses the parameters from the last successful ``connect()`` call so
+        the BBMD foreign-device registration is re-issued with the same
+        address and TTL.  This is required after a network outage longer
+        than the BBMD TTL (default 900 s), because the BBMD drops the
+        registration once it expires and stops forwarding packets until we
+        re-register (issue #18).
+
+        Safe to call even when already disconnected — ``disconnect()``
+        tolerates a missing ``_app``.
+        """
+        bbmd_address = self._last_bbmd_address
+        bbmd_ttl = self._last_bbmd_ttl
+        _LOGGER.info(
+            "Reconnecting BACnet client (bbmd=%s, ttl=%s)",
+            _mask_address(bbmd_address) if bbmd_address else "none",
+            bbmd_ttl,
+        )
+        await self.disconnect()
+        await self.connect(bbmd_address=bbmd_address, bbmd_ttl=bbmd_ttl)
 
     async def disconnect(self) -> None:
         """Shut down the BACpypes3 application and release the UDP socket."""

--- a/custom_components/bacnet/const.py
+++ b/custom_components/bacnet/const.py
@@ -52,6 +52,15 @@ DEFAULT_ENABLE_COV = True
 DEFAULT_USE_DESCRIPTION = False
 DEFAULT_COV_INCREMENT = 0.1  # default COV increment for analog objects
 
+# Resilience thresholds for outage recovery (issue #18).
+# After MAX_SILENT_FAILURES consecutive failed polls, raise UpdateFailed so HA
+# surfaces the outage and applies its native backoff.  After RECONNECT_THRESHOLD
+# consecutive failures, the underlying BACnetClient is reconnected (re-binds the
+# UDP socket and re-registers with the BBMD, which is needed when the foreign
+# device registration TTL has expired during a network outage).
+MAX_SILENT_FAILURES = 3
+RECONNECT_THRESHOLD = 10
+
 # ---------------------------------------------------------------------------
 # BACnet object type IDs  (from ASHRAE 135)
 # ---------------------------------------------------------------------------

--- a/custom_components/bacnet/coordinator.py
+++ b/custom_components/bacnet/coordinator.py
@@ -19,7 +19,7 @@ from typing import Any
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .bacnet_client import BACnetClient
 from .const import (
@@ -29,11 +29,13 @@ from .const import (
     DEFAULT_POLLING_INTERVAL,
     DEFAULT_USE_DESCRIPTION,
     DOMAIN,
+    MAX_SILENT_FAILURES,
     OBJECT_TYPE_ANALOG_INPUT,
     OBJECT_TYPE_ANALOG_OUTPUT,
     OBJECT_TYPE_ANALOG_VALUE,
     OBJECT_TYPE_BINARY_VALUE,
     OBJECT_TYPE_MULTI_STATE_VALUE,
+    RECONNECT_THRESHOLD,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -93,6 +95,16 @@ class BACnetCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self._cov_subscriptions: dict[str, str] = {}  # obj_key → sub_key
         self._polled_objects: list[dict[str, Any]] = []
 
+        # Outage-recovery state (issue #18).
+        # _consecutive_failures counts polls in a row that returned no usable
+        # data.  At MAX_SILENT_FAILURES we raise UpdateFailed so HA surfaces
+        # the outage + applies native backoff.  At RECONNECT_THRESHOLD we
+        # additionally reconnect the underlying BACnetClient once (re-registers
+        # with the BBMD whose TTL has expired).  _needs_resubscribe is set
+        # after a reconnect so the next successful poll re-creates COV subs.
+        self._consecutive_failures: int = 0
+        self._needs_resubscribe: bool = False
+
         # Device address for reads/writes (from config entry data)
         self.device_address: str = ""
         if entry is not None:
@@ -121,8 +133,20 @@ class BACnetCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         always refreshed — even when a device accepts a COV subscription
         but never actually sends notifications.
 
+        Outage recovery (issue #18): if every object fails to return a real
+        presentValue for MAX_SILENT_FAILURES polls in a row, raise
+        UpdateFailed so HA surfaces the outage and applies native backoff.
+        At RECONNECT_THRESHOLD consecutive failures, additionally reconnect
+        the underlying BACnetClient once (re-registers with the BBMD whose
+        TTL has expired).  After a successful poll following a reconnect,
+        COV subscriptions are re-created.
+
         Returns:
             Dict keyed by "object_type:instance" → {property: value}.
+
+        Raises:
+            UpdateFailed: when the device has been unreachable for
+                          MAX_SILENT_FAILURES consecutive polls.
         """
         # Use existing data as base (COV may have already pushed updates)
         data: dict[str, Any] = dict(self.data) if self.data else {}
@@ -147,12 +171,93 @@ class BACnetCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             data.update(polled)
         except Exception as exc:  # noqa: BLE001
             _LOGGER.warning("Batch poll failed: %s — keeping stale data", exc)
+            polled = None
             for obj in self.objects:
                 obj_key = f"{obj['object_type']}:{obj['instance']}"
                 if obj_key not in data:
                     data[obj_key] = {"presentValue": None, "statusFlags": None}
 
+        # --- Outage detection -------------------------------------------------
+        # A poll is "successful" if at least one object returned a non-None
+        # presentValue.  Empty / all-None results mean the device is not
+        # responding — even when poll_objects() returned without raising,
+        # BACpypes3 timeouts surface as None values rather than exceptions.
+        if self._poll_yielded_data(polled):
+            self._consecutive_failures = 0
+            # After a reconnect, rebuild COV subscriptions once the device is
+            # confirmed reachable again.
+            if self._needs_resubscribe:
+                await self._restore_subscriptions()
+        else:
+            await self._handle_poll_failure()
+
         return data
+
+    @staticmethod
+    def _poll_yielded_data(
+        polled: dict[str, dict[str, Any]] | None,
+    ) -> bool:
+        """Return True if at least one object returned a real presentValue."""
+        if not polled:
+            return False
+        for obj_data in polled.values():
+            if obj_data.get("presentValue") is not None:
+                return True
+        return False
+
+    async def _handle_poll_failure(self) -> None:
+        """Account for one failed poll and trigger recovery if needed.
+
+        - Below MAX_SILENT_FAILURES: keep stale data (avoids flapping on
+          brief network blips) and return normally.
+        - At/above MAX_SILENT_FAILURES: raise UpdateFailed so HA surfaces
+          the outage and applies native backoff.
+        - At exactly RECONNECT_THRESHOLD: reconnect the BACnetClient once
+          (re-registers with the BBMD after TTL expiry).
+        """
+        self._consecutive_failures += 1
+        failures = self._consecutive_failures
+        _LOGGER.warning(
+            "BACnet device %s unresponsive (%d consecutive failed polls)",
+            self.device_address or "(no address)",
+            failures,
+        )
+
+        if failures == RECONNECT_THRESHOLD:
+            _LOGGER.warning(
+                "Attempting BACnet client reconnect after %d failed polls",
+                failures,
+            )
+            try:
+                await self.client.reconnect()
+                self._needs_resubscribe = True
+                _LOGGER.info(
+                    "BACnet client reconnected — next poll will resubscribe COV"
+                )
+            except Exception as exc:  # noqa: BLE001
+                _LOGGER.error("BACnet client reconnect failed: %s", exc)
+
+        if failures >= MAX_SILENT_FAILURES:
+            raise UpdateFailed(
+                f"BACnet device {self.device_address or '(no address)'} not "
+                f"responding ({failures} consecutive failed polls)"
+            )
+
+    async def _restore_subscriptions(self) -> None:
+        """Re-create COV subscriptions after a reconnect.
+
+        The previous _cov_subscriptions mapping references sub_keys whose
+        reader tasks died during the outage, so we clear both bookkeeping
+        dicts and re-run _setup_subscriptions() which re-subscribes COV
+        where possible and rebuilds the polling fallback list.
+        """
+        _LOGGER.info("Restoring COV subscriptions after reconnect")
+        # Cancel any lingering sub keys (tasks are already dead post-reconnect
+        # but clearing the mapping ensures a clean rebuild).
+        self._cov_subscriptions.clear()
+        self._polled_objects.clear()
+        await self._setup_subscriptions()
+        self._needs_resubscribe = False
 
     # ------------------------------------------------------------------
     # COV subscription management

--- a/custom_components/bacnet/manifest.json
+++ b/custom_components/bacnet/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/CervezaStallone/Home-Assistant-BACnet-intergration/issues",
   "requirements": ["BACpypes3==0.0.99"],
-  "version": "1.0.19"
+  "version": "1.0.20"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[tool.pytest.ini_options]
+pythonpath = ["."]
+testpaths = ["tests"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,293 @@
+"""
+Lightweight HA stubs so tests run without Home Assistant installed.
+
+All HA modules are registered in sys.modules BEFORE any integration code
+is imported, so every 'from homeassistant…' inside the integration gets
+these stubs instead of the real HA package.
+"""
+
+from __future__ import annotations
+
+import sys
+from enum import Enum
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Core stubs
+# ---------------------------------------------------------------------------
+
+
+def _noop_callback(fn):
+    """Stub for HA's @callback decorator — returns the function unchanged."""
+    return fn
+
+
+class _DataUpdateCoordinator:
+    """Minimal DataUpdateCoordinator stub."""
+
+    def __init__(self, hass, logger, *, name, update_interval):
+        self.hass = hass
+        self.name = name
+        self.data = None
+        self._listeners: dict = {}
+
+    # Allow DataUpdateCoordinator[SomeType] generic syntax (Python 3.9+)
+    def __class_getitem__(cls, item):
+        return cls
+
+    def async_update_listeners(self) -> None:
+        pass
+
+    async def async_config_entry_first_refresh(self) -> None:
+        pass
+
+    async def async_request_refresh(self) -> None:
+        pass
+
+
+class _CoordinatorEntity:
+    """Minimal CoordinatorEntity stub."""
+
+    _attr_has_entity_name = False
+    _attr_unique_id: str | None = None
+    _attr_name: str | None = None
+    _attr_device_info: dict | None = None
+    hass: Any = None
+
+    def __init__(self, coordinator) -> None:
+        self.coordinator = coordinator
+
+    def __class_getitem__(cls, item):
+        return cls
+
+
+class _DeviceInfo(dict):
+    """Stub for HA's DeviceInfo TypedDict — just a dict."""
+
+    def __init__(self, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+
+
+# ---------------------------------------------------------------------------
+# Platform stubs
+# ---------------------------------------------------------------------------
+
+
+class _SensorEntity(_CoordinatorEntity):
+    _attr_device_class = None
+    _attr_native_unit_of_measurement = None
+    _attr_state_class = None
+
+
+class _SensorDeviceClass:
+    TEMPERATURE = "temperature"
+    HUMIDITY = "humidity"
+    PRESSURE = "pressure"
+    POWER = "power"
+    ENERGY = "energy"
+    CURRENT = "current"
+    VOLTAGE = "voltage"
+    FREQUENCY = "frequency"
+    VOLUME_FLOW_RATE = "volume_flow_rate"
+
+
+class _SensorStateClass:
+    MEASUREMENT = "measurement"
+
+
+class _BinarySensorEntity(_CoordinatorEntity):
+    pass
+
+
+class _SwitchEntity(_CoordinatorEntity):
+    pass
+
+
+class _NumberMode(str, Enum):
+    BOX = "box"
+
+
+class _NumberEntity(_CoordinatorEntity):
+    _attr_mode = None
+    _attr_native_min_value: float | None = None
+    _attr_native_max_value: float | None = None
+    _attr_native_step: float | None = None
+    _attr_native_unit_of_measurement: str | None = None
+
+
+class _ClimateEntityFeature(int, Enum):
+    TARGET_TEMPERATURE = 1
+    TURN_ON = 2
+    TURN_OFF = 4
+
+
+class _HVACMode(str, Enum):
+    HEAT = "heat"
+    OFF = "off"
+
+
+class _UnitOfTemperature(str, Enum):
+    CELSIUS = "°C"
+    FAHRENHEIT = "°F"
+
+
+class _ClimateEntity(_CoordinatorEntity):
+    _attr_supported_features = None
+    _attr_hvac_modes: list | None = None
+    _attr_target_temperature_step: float | None = None
+    _attr_min_temp: float | None = None
+    _attr_max_temp: float | None = None
+    _attr_temperature_unit: str | None = None
+
+
+class _Platform(str, Enum):
+    SENSOR = "sensor"
+    BINARY_SENSOR = "binary_sensor"
+    SWITCH = "switch"
+    NUMBER = "number"
+    CLIMATE = "climate"
+
+
+# ---------------------------------------------------------------------------
+# Build mock modules
+# ---------------------------------------------------------------------------
+
+_ha_core = MagicMock()
+_ha_core.callback = _noop_callback
+_ha_core.HomeAssistant = MagicMock
+_ha_core.CALLBACK_TYPE = MagicMock
+
+_ha_config_entries = MagicMock()
+_ha_config_entries.ConfigEntry = MagicMock
+_ha_config_entries.OptionsFlow = object  # options_flow inherits from this
+
+_ha_const = MagicMock()
+_ha_const.Platform = _Platform
+_ha_const.ATTR_TEMPERATURE = "temperature"
+_ha_const.UnitOfTemperature = _UnitOfTemperature
+
+_ha_exceptions = MagicMock()
+_ha_exceptions.ConfigEntryNotReady = Exception
+
+_ha_coordinator_mod = MagicMock()
+_ha_coordinator_mod.CoordinatorEntity = _CoordinatorEntity
+_ha_coordinator_mod.DataUpdateCoordinator = _DataUpdateCoordinator
+_ha_coordinator_mod.UpdateFailed = Exception
+
+_ha_device_registry = MagicMock()
+_ha_device_registry.DeviceInfo = _DeviceInfo
+
+_ha_sensor_mod = MagicMock()
+_ha_sensor_mod.SensorEntity = _SensorEntity
+_ha_sensor_mod.SensorDeviceClass = _SensorDeviceClass
+_ha_sensor_mod.SensorStateClass = _SensorStateClass
+
+_ha_binary_sensor_mod = MagicMock()
+_ha_binary_sensor_mod.BinarySensorEntity = _BinarySensorEntity
+
+_ha_switch_mod = MagicMock()
+_ha_switch_mod.SwitchEntity = _SwitchEntity
+
+_ha_number_mod = MagicMock()
+_ha_number_mod.NumberEntity = _NumberEntity
+_ha_number_mod.NumberMode = _NumberMode
+
+_ha_climate_mod = MagicMock()
+_ha_climate_mod.ClimateEntity = _ClimateEntity
+_ha_climate_mod.ClimateEntityFeature = _ClimateEntityFeature
+_ha_climate_mod.HVACMode = _HVACMode
+
+_voluptuous = MagicMock()
+_voluptuous.Schema = dict  # vol.Schema({…}) → just a dict for stub purposes
+
+_ha_flow = MagicMock()
+
+sys.modules.update(
+    {
+        "homeassistant": MagicMock(),
+        "homeassistant.core": _ha_core,
+        "homeassistant.config_entries": _ha_config_entries,
+        "homeassistant.const": _ha_const,
+        "homeassistant.exceptions": _ha_exceptions,
+        "homeassistant.components": MagicMock(),
+        "homeassistant.components.sensor": _ha_sensor_mod,
+        "homeassistant.components.binary_sensor": _ha_binary_sensor_mod,
+        "homeassistant.components.switch": _ha_switch_mod,
+        "homeassistant.components.number": _ha_number_mod,
+        "homeassistant.components.climate": _ha_climate_mod,
+        "homeassistant.helpers": MagicMock(),
+        "homeassistant.helpers.update_coordinator": _ha_coordinator_mod,
+        "homeassistant.helpers.device_registry": _ha_device_registry,
+        "homeassistant.helpers.entity_platform": MagicMock(),
+        "homeassistant.helpers.config_validation": MagicMock(),
+        "homeassistant.data_entry_flow": _ha_flow,
+        "voluptuous": _voluptuous,
+    }
+)
+
+
+# ---------------------------------------------------------------------------
+# Shared fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_coordinator(data: dict | None = None) -> MagicMock:
+    coord = MagicMock()
+    coord.data = data or {}
+    coord.device_address = "192.168.1.100"
+    coord.get_object_value.side_effect = lambda key, prop="presentValue": (
+        coord.data.get(key, {}).get(prop)
+    )
+    coord.get_entity_name.return_value = "Test Object"
+    coord.get_update_method.return_value = "polling"
+    coord.get_cov_increment_for.return_value = None
+    coord.is_cov_subscribed.return_value = False
+    return coord
+
+
+def _make_entry(
+    device_id: int = 1001,
+    device_name: str = "Test Device",
+    vendor_name: str = "ACME Corp",
+    model_name: str = "Model X",
+    firmware_version: str = "2.3",
+    software_version: str = "1.0",
+    device_address: str = "192.168.1.100",
+) -> MagicMock:
+    entry = MagicMock()
+    entry.entry_id = "test_entry_id"
+    entry.data = {
+        "device_id": device_id,
+        "device_name": device_name,
+        "vendor_name": vendor_name,
+        "model_name": model_name,
+        "firmware_version": firmware_version,
+        "software_version": software_version,
+        "device_address": device_address,
+    }
+    entry.options = {}
+    return entry
+
+
+@pytest.fixture
+def coordinator():
+    return _make_coordinator()
+
+
+@pytest.fixture
+def entry():
+    return _make_entry()
+
+
+@pytest.fixture
+def coordinator_with_data():
+    return _make_coordinator(
+        {
+            "0:1": {"presentValue": 23.5, "statusFlags": [False, False, False, False]},
+            "4:2": {"presentValue": 1, "statusFlags": [False, False, False, False]},
+        }
+    )

--- a/tests/test_bacnet_client.py
+++ b/tests/test_bacnet_client.py
@@ -1,0 +1,264 @@
+"""
+Tests for BACnetClient pure-Python logic.
+
+Network I/O is NOT tested here — those require a real or simulated BACnet
+device. This file covers deterministic static/class methods that can be
+verified without any network.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from custom_components.bacnet.bacnet_client import BACnetClient
+
+# ---------------------------------------------------------------------------
+# Attempt to import BACpypes3 primitives for _coerce_value tests.
+# If not installed the coerce-value suite is skipped gracefully.
+# ---------------------------------------------------------------------------
+try:
+    from bacpypes3.primitivedata import (
+        CharacterString,
+        Enumerated,
+        Real,
+        Unsigned,
+    )
+
+    _BACPYPES3_AVAILABLE = True
+except ImportError:
+    _BACPYPES3_AVAILABLE = False
+
+bacpypes3_required = pytest.mark.skipif(
+    not _BACPYPES3_AVAILABLE, reason="bacpypes3 not installed"
+)
+
+
+# ---------------------------------------------------------------------------
+# _coerce_value
+# ---------------------------------------------------------------------------
+
+
+class TestCoerceValue:
+    def test_none(self):
+        assert BACnetClient._coerce_value(None) is None
+
+    def test_plain_int_roundtrips(self):
+        result = BACnetClient._coerce_value(42)
+        assert result == 42
+        assert type(result) is int
+
+    def test_plain_float_roundtrips(self):
+        result = BACnetClient._coerce_value(3.14)
+        assert abs(result - 3.14) < 1e-9
+        assert type(result) is float
+
+    def test_plain_bool_preserved(self):
+        assert BACnetClient._coerce_value(True) is True
+        assert BACnetClient._coerce_value(False) is False
+
+    def test_plain_str_roundtrips(self):
+        result = BACnetClient._coerce_value("hello")
+        assert result == "hello"
+        assert type(result) is str
+
+    def test_list_converted_to_bool_list(self):
+        # StatusFlags-style: [False, True, False, False]
+        result = BACnetClient._coerce_value([False, True, False, False])
+        assert result == [False, True, False, False]
+        assert all(type(x) is bool for x in result)
+
+    def test_list_of_ints_converted_to_bools(self):
+        result = BACnetClient._coerce_value([0, 1, 0, 0])
+        assert result == [False, True, False, False]
+
+    @bacpypes3_required
+    def test_real_returns_float(self):
+        result = BACnetClient._coerce_value(Real(23.5))
+        assert result == pytest.approx(23.5)
+        assert type(result) is float
+
+    @bacpypes3_required
+    def test_unsigned_returns_int(self):
+        result = BACnetClient._coerce_value(Unsigned(7))
+        assert result == 7
+        assert type(result) is int
+
+    @bacpypes3_required
+    def test_character_string_returns_str(self):
+        result = BACnetClient._coerce_value(CharacterString("Zone 1"))
+        assert result == "Zone 1"
+        assert type(result) is str
+
+    @bacpypes3_required
+    def test_enumerated_returns_plain_int(self):
+        """Enumerated is an int subclass; must return a plain Python int."""
+        result = BACnetClient._coerce_value(Enumerated(1))
+        assert result == 1
+        assert type(result) is int  # NOT Enumerated
+
+    @bacpypes3_required
+    def test_enumerated_zero_is_false_when_bool(self):
+        result = BACnetClient._coerce_value(Enumerated(0))
+        assert result == 0
+        assert type(result) is int
+
+    def test_fallback_converts_to_str(self):
+        class Weird:
+            def __str__(self):
+                return "weird-value"
+
+        result = BACnetClient._coerce_value(Weird())
+        assert result == "weird-value"
+        assert isinstance(result, str)
+
+
+# ---------------------------------------------------------------------------
+# _derive_device_instance
+# ---------------------------------------------------------------------------
+
+
+class TestDeriveDeviceInstance:
+    def test_deterministic(self):
+        a = BACnetClient._derive_device_instance("192.168.1.1", 47808)
+        b = BACnetClient._derive_device_instance("192.168.1.1", 47808)
+        assert a == b
+
+    def test_different_ip_gives_different_instance(self):
+        a = BACnetClient._derive_device_instance("192.168.1.1", 47808)
+        b = BACnetClient._derive_device_instance("192.168.1.2", 47808)
+        assert a != b
+
+    def test_different_port_gives_different_instance(self):
+        a = BACnetClient._derive_device_instance("192.168.1.1", 47808)
+        b = BACnetClient._derive_device_instance("192.168.1.1", 47809)
+        assert a != b
+
+    def test_result_in_valid_range(self):
+        instance = BACnetClient._derive_device_instance("10.0.0.1", 47808)
+        assert 3_900_000 <= instance <= 4_194_302
+
+    def test_empty_ip(self):
+        instance = BACnetClient._derive_device_instance("", 47808)
+        assert 3_900_000 <= instance <= 4_194_302
+
+
+# ---------------------------------------------------------------------------
+# _object_type_str_to_int / _INT_TO_TYPE_STR
+# ---------------------------------------------------------------------------
+
+
+class TestObjectTypeMapping:
+    @pytest.mark.parametrize(
+        "name, expected",
+        [
+            ("analog-input", 0),
+            ("analog-output", 1),
+            ("analog-value", 2),
+            ("binary-input", 3),
+            ("binary-output", 4),
+            ("binary-value", 5),
+            ("multi-state-input", 13),
+            ("multi-state-output", 14),
+            ("multi-state-value", 19),
+            # camelCase aliases
+            ("analogInput", 0),
+            ("binaryValue", 5),
+            ("multiStateOutput", 14),
+        ],
+    )
+    def test_str_to_int(self, name, expected):
+        assert BACnetClient._object_type_str_to_int(name) == expected
+
+    def test_int_passthrough(self):
+        assert BACnetClient._object_type_str_to_int(2) == 2
+
+    def test_unknown_returns_none(self):
+        assert BACnetClient._object_type_str_to_int("unknown-type") is None
+
+    @pytest.mark.parametrize(
+        "type_int, expected_str",
+        [
+            (0, "analog-input"),
+            (1, "analog-output"),
+            (4, "binary-output"),
+            (5, "binary-value"),
+            (19, "multi-state-value"),
+        ],
+    )
+    def test_int_to_str(self, type_int, expected_str):
+        assert BACnetClient._INT_TO_TYPE_STR[type_int] == expected_str
+
+
+# ---------------------------------------------------------------------------
+# _CAMEL_TO_HYPHEN / _HYPHEN_TO_CAMEL
+# ---------------------------------------------------------------------------
+
+
+class TestPropertyNameMaps:
+    def test_camel_to_hyphen(self):
+        assert BACnetClient._CAMEL_TO_HYPHEN["presentValue"] == "present-value"
+        assert BACnetClient._CAMEL_TO_HYPHEN["statusFlags"] == "status-flags"
+
+    def test_hyphen_to_camel_is_inverse(self):
+        for camel, hyphen in BACnetClient._CAMEL_TO_HYPHEN.items():
+            assert BACnetClient._HYPHEN_TO_CAMEL[hyphen] == camel
+
+
+# ---------------------------------------------------------------------------
+# reconnect() — issue #18 outage recovery
+# ---------------------------------------------------------------------------
+
+
+class TestReconnect:
+    """reconnect() must re-issue connect() with the previously used BBMD params."""
+
+    def test_reconnect_uses_stored_bbmd_params(self, monkeypatch):
+        client = BACnetClient(local_ip="127.0.0.1", local_port=47809)
+
+        # Simulate a prior successful connect() with BBMD parameters.
+        client._last_bbmd_address = "10.0.0.1:47808"
+        client._last_bbmd_ttl = 600
+
+        calls: list[tuple] = []
+
+        async def fake_disconnect(self):
+            calls.append(("disconnect",))
+
+        async def fake_connect(self, bbmd_address=None, bbmd_ttl=900):
+            calls.append(("connect", bbmd_address, bbmd_ttl))
+
+        # Bind as plain functions taking self (unbound-method style).
+        monkeypatch.setattr(BACnetClient, "disconnect", fake_disconnect)
+        monkeypatch.setattr(BACnetClient, "connect", fake_connect)
+
+        import asyncio
+
+        asyncio.run(client.reconnect())
+
+        assert calls[0] == ("disconnect",)
+        assert calls[1] == ("connect", "10.0.0.1:47808", 600)
+
+    def test_reconnect_defaults_when_never_connected(self, monkeypatch):
+        """A fresh client that never called connect() reconnects without BBMD."""
+        client = BACnetClient(local_ip="127.0.0.1", local_port=47810)
+
+        assert client._last_bbmd_address is None
+        assert client._last_bbmd_ttl == 900
+
+        calls: list[tuple] = []
+
+        async def fake_disconnect(self):
+            calls.append(("disconnect",))
+
+        async def fake_connect(self, bbmd_address=None, bbmd_ttl=900):
+            calls.append(("connect", bbmd_address, bbmd_ttl))
+
+        monkeypatch.setattr(BACnetClient, "disconnect", fake_disconnect)
+        monkeypatch.setattr(BACnetClient, "connect", fake_connect)
+
+        import asyncio
+
+        asyncio.run(client.reconnect())
+
+        assert calls[0] == ("disconnect",)
+        assert calls[1] == ("connect", None, 900)

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1,0 +1,407 @@
+"""Tests for BACnetCoordinator domain mapping and helper methods."""
+
+from __future__ import annotations
+
+import pytest
+
+from custom_components.bacnet.const import (
+    OBJECT_TYPE_ANALOG_INPUT,
+    OBJECT_TYPE_ANALOG_OUTPUT,
+    OBJECT_TYPE_ANALOG_VALUE,
+    OBJECT_TYPE_BINARY_INPUT,
+    OBJECT_TYPE_BINARY_OUTPUT,
+    OBJECT_TYPE_BINARY_VALUE,
+    OBJECT_TYPE_MULTI_STATE_INPUT,
+    OBJECT_TYPE_MULTI_STATE_OUTPUT,
+    OBJECT_TYPE_MULTI_STATE_VALUE,
+)
+from custom_components.bacnet.coordinator import BACnetCoordinator
+
+
+def _make_coordinator(objects=None, domain_overrides=None):
+    """Return a BACnetCoordinator with mocked dependencies."""
+    from unittest.mock import MagicMock
+
+    client = MagicMock()
+    entry = MagicMock()
+    entry.entry_id = "test"
+    entry.data = {"device_address": "192.168.1.100"}
+
+    coord = BACnetCoordinator(
+        hass=MagicMock(),
+        client=client,
+        objects=objects or [],
+        domain_overrides=domain_overrides or {},
+        entry=entry,
+    )
+    return coord
+
+
+# ---------------------------------------------------------------------------
+# _default_domain_for — commandable-aware domain selection
+# ---------------------------------------------------------------------------
+
+
+class TestDefaultDomainFor:
+    @pytest.mark.parametrize(
+        "obj_type, commandable, expected",
+        [
+            # Input types — always read-only
+            (OBJECT_TYPE_ANALOG_INPUT, False, "sensor"),
+            (OBJECT_TYPE_BINARY_INPUT, False, "binary_sensor"),
+            (OBJECT_TYPE_MULTI_STATE_INPUT, False, "sensor"),
+            # Output types — always commandable
+            (OBJECT_TYPE_ANALOG_OUTPUT, True, "number"),
+            (OBJECT_TYPE_BINARY_OUTPUT, True, "switch"),
+            (OBJECT_TYPE_MULTI_STATE_OUTPUT, True, "number"),
+            # Value types: commandable → writable domain
+            (OBJECT_TYPE_ANALOG_VALUE, True, "number"),
+            (OBJECT_TYPE_ANALOG_VALUE, False, "sensor"),
+            (OBJECT_TYPE_BINARY_VALUE, True, "switch"),
+            (OBJECT_TYPE_BINARY_VALUE, False, "binary_sensor"),
+            (OBJECT_TYPE_MULTI_STATE_VALUE, True, "number"),
+            (OBJECT_TYPE_MULTI_STATE_VALUE, False, "sensor"),
+        ],
+    )
+    def test_domain(self, obj_type, commandable, expected):
+        coord = _make_coordinator()
+        obj = {"object_type": obj_type, "instance": 1, "commandable": commandable}
+        assert coord._default_domain_for(obj) == expected
+
+    def test_non_commandable_bv_is_not_switch(self):
+        """Critical: non-commandable BV must NOT become a switch."""
+        coord = _make_coordinator()
+        obj = {
+            "object_type": OBJECT_TYPE_BINARY_VALUE,
+            "instance": 5,
+            "commandable": False,
+        }
+        assert coord._default_domain_for(obj) == "binary_sensor"
+        assert coord._default_domain_for(obj) != "switch"
+
+
+# ---------------------------------------------------------------------------
+# get_domain_for_object — overrides take precedence
+# ---------------------------------------------------------------------------
+
+
+class TestGetDomainForObject:
+    def test_override_wins(self):
+        coord = _make_coordinator(domain_overrides={"2:1": "climate"})
+        obj = {
+            "object_type": OBJECT_TYPE_ANALOG_VALUE,
+            "instance": 1,
+            "commandable": False,
+        }
+        assert coord.get_domain_for_object(obj) == "climate"
+
+    def test_no_override_uses_default(self):
+        coord = _make_coordinator()
+        obj = {
+            "object_type": OBJECT_TYPE_ANALOG_INPUT,
+            "instance": 3,
+            "commandable": False,
+        }
+        assert coord.get_domain_for_object(obj) == "sensor"
+
+    def test_override_key_is_type_colon_instance(self):
+        coord = _make_coordinator(domain_overrides={"5:10": "sensor"})
+        obj = {
+            "object_type": OBJECT_TYPE_BINARY_VALUE,
+            "instance": 10,
+            "commandable": True,
+        }
+        # Override should win over commandable-based default (switch)
+        assert coord.get_domain_for_object(obj) == "sensor"
+
+
+# ---------------------------------------------------------------------------
+# get_entity_name
+# ---------------------------------------------------------------------------
+
+
+class TestGetEntityName:
+    def test_returns_object_name_by_default(self):
+        coord = _make_coordinator()
+        obj = {
+            "object_type": 0,
+            "instance": 1,
+            "object_name": "Room Temp",
+            "description": "Room temperature sensor",
+        }
+        assert coord.get_entity_name(obj) == "Room Temp"
+
+    def test_returns_description_when_use_description_enabled(self):
+        coord = _make_coordinator()
+        coord.use_description = True
+        obj = {
+            "object_type": 0,
+            "instance": 1,
+            "object_name": "Room Temp",
+            "description": "Room temperature sensor",
+        }
+        assert coord.get_entity_name(obj) == "Room temperature sensor"
+
+    def test_falls_back_to_object_name_when_no_description(self):
+        coord = _make_coordinator()
+        coord.use_description = True
+        obj = {
+            "object_type": 0,
+            "instance": 1,
+            "object_name": "Zone 1",
+            "description": "",
+        }
+        assert coord.get_entity_name(obj) == "Zone 1"
+
+    def test_fallback_when_no_object_name(self):
+        coord = _make_coordinator()
+        obj = {"object_type": 0, "instance": 5}
+        assert "0:5" in coord.get_entity_name(obj) or "BACnet" in coord.get_entity_name(
+            obj
+        )
+
+
+# ---------------------------------------------------------------------------
+# get_update_method / is_cov_subscribed
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateMethod:
+    def test_polling_by_default(self):
+        coord = _make_coordinator()
+        assert coord.get_update_method("0:1") == "polling"
+
+    def test_cov_when_subscribed(self):
+        coord = _make_coordinator()
+        coord._cov_subscriptions["0:1"] = "sub_key"
+        assert coord.is_cov_subscribed("0:1") is True
+        assert coord.get_update_method("0:1") == "COV"
+
+
+# ---------------------------------------------------------------------------
+# COV notification merge
+# ---------------------------------------------------------------------------
+
+
+class TestCOVNotification:
+    def test_merges_into_existing_data(self):
+        coord = _make_coordinator()
+        coord.data = {"0:1": {"presentValue": 20.0, "statusFlags": [False] * 4}}
+        coord._handle_cov_notification("0:1", {"presentValue": 25.0})
+        assert coord.data["0:1"]["presentValue"] == 25.0
+        assert coord.data["0:1"]["statusFlags"] == [False] * 4  # untouched
+
+    def test_creates_new_key_if_missing(self):
+        coord = _make_coordinator()
+        coord.data = {}
+        coord._handle_cov_notification("2:3", {"presentValue": 1.0})
+        assert coord.data["2:3"]["presentValue"] == 1.0
+
+    def test_noop_when_data_is_none(self):
+        coord = _make_coordinator()
+        coord.data = None
+        coord._handle_cov_notification("0:1", {"presentValue": 5.0})
+        assert coord.data is None
+
+
+# ---------------------------------------------------------------------------
+# Outage recovery — issue #18
+# ---------------------------------------------------------------------------
+
+
+# UpdateFailed is imported via the HA update_coordinator stub. The stub maps
+# UpdateFailed to a real Exception subclass in conftest.py via the
+# DataUpdateCoordinator stub module; fetch it lazily so this file imports
+# cleanly whether or not the symbol is present.
+def _update_failed_type():
+    from homeassistant.helpers.update_coordinator import UpdateFailed
+
+    return UpdateFailed
+
+
+class TestPollYieldCheck:
+    """The _poll_yielded_data static method defines what counts as a successful poll."""
+
+    def test_none_polled_is_failure(self):
+        assert BACnetCoordinator._poll_yielded_data(None) is False
+
+    def test_empty_polled_is_failure(self):
+        assert BACnetCoordinator._poll_yielded_data({}) is False
+
+    def test_all_none_present_values_is_failure(self):
+        polled = {"0:1": {"presentValue": None}, "4:2": {"presentValue": None}}
+        assert BACnetCoordinator._poll_yielded_data(polled) is False
+
+    def test_one_real_value_is_success(self):
+        polled = {
+            "0:1": {"presentValue": None},
+            "4:2": {"presentValue": 1},
+        }
+        assert BACnetCoordinator._poll_yielded_data(polled) is True
+
+
+class TestFailureTracking:
+    """Consecutive failed polls must raise UpdateFailed after MAX_SILENT_FAILURES."""
+
+    def test_first_failure_keeps_stale_data(self):
+        """Below threshold, _handle_poll_failure returns normally."""
+        import asyncio
+
+        coord = _make_coordinator(objects=[{"object_type": 0, "instance": 1}])
+        # Should not raise.
+        asyncio.run(coord._handle_poll_failure())
+        assert coord._consecutive_failures == 1
+
+    def test_third_failure_raises_update_failed(self):
+        import asyncio
+
+        coord = _make_coordinator(objects=[{"object_type": 0, "instance": 1}])
+        coord._consecutive_failures = 2  # already at 2
+
+        UpdateFailed = _update_failed_type()
+        with pytest.raises(UpdateFailed):
+            asyncio.run(coord._handle_poll_failure())
+        assert coord._consecutive_failures == 3
+
+    def test_success_resets_counter(self):
+        """A successful poll path must reset _consecutive_failures to 0."""
+        import asyncio
+
+        from unittest.mock import AsyncMock
+
+        coord = _make_coordinator(objects=[{"object_type": 0, "instance": 1}])
+        coord._consecutive_failures = 5
+        # Stub setup so we test the poll path in isolation.
+        coord._setup_subscriptions = AsyncMock()
+        # Make poll_objects return real data.
+        coord.client.poll_objects = AsyncMock(
+            return_value={"0:1": {"presentValue": 23.5, "statusFlags": [False] * 4}}
+        )
+
+        asyncio.run(coord._async_update_data())
+
+        assert coord._consecutive_failures == 0
+
+
+class TestReconnectTrigger:
+    """At RECONNECT_THRESHOLD failures, client.reconnect() is called exactly once."""
+
+    def test_reconnect_called_at_threshold(self):
+        import asyncio
+
+        from unittest.mock import AsyncMock
+
+        coord = _make_coordinator(objects=[{"object_type": 0, "instance": 1}])
+        coord._consecutive_failures = 9  # one away from RECONNECT_THRESHOLD (10)
+        coord.client.reconnect = AsyncMock()
+
+        # failures become 10 → triggers reconnect AND raises UpdateFailed.
+        UpdateFailed = _update_failed_type()
+        with pytest.raises(UpdateFailed):
+            asyncio.run(coord._handle_poll_failure())
+
+        coord.client.reconnect.assert_awaited_once()
+        assert coord._needs_resubscribe is True
+
+    def test_reconnect_not_called_below_threshold(self):
+        import asyncio
+
+        from unittest.mock import AsyncMock
+
+        coord = _make_coordinator(objects=[{"object_type": 0, "instance": 1}])
+        coord._consecutive_failures = 0
+        coord.client.reconnect = AsyncMock()
+
+        asyncio.run(coord._handle_poll_failure())
+
+        coord.client.reconnect.assert_not_awaited()
+        assert coord._needs_resubscribe is False
+
+    def test_reconnect_called_only_once_per_outage(self):
+        """Past RECONNECT_THRESHOLD, subsequent failures must NOT re-trigger."""
+        import asyncio
+
+        from unittest.mock import AsyncMock
+
+        coord = _make_coordinator(objects=[{"object_type": 0, "instance": 1}])
+        coord._consecutive_failures = 20  # well past threshold
+        coord.client.reconnect = AsyncMock()
+
+        UpdateFailed = _update_failed_type()
+        with pytest.raises(UpdateFailed):
+            asyncio.run(coord._handle_poll_failure())
+
+        coord.client.reconnect.assert_not_awaited()
+
+    def test_reconnect_failure_does_not_crash_coordinator(self):
+        """If client.reconnect() raises, _handle_poll_failure must absorb it."""
+        import asyncio
+
+        from unittest.mock import AsyncMock
+
+        coord = _make_coordinator(objects=[{"object_type": 0, "instance": 1}])
+        coord._consecutive_failures = 9
+        coord.client.reconnect = AsyncMock(side_effect=RuntimeError("boom"))
+
+        # Should not raise the inner RuntimeError; it surfaces as UpdateFailed
+        # because failures (10) >= MAX_SILENT_FAILURES (3).
+        UpdateFailed = _update_failed_type()
+        with pytest.raises(UpdateFailed):
+            asyncio.run(coord._handle_poll_failure())
+        # needs_resubscribe stays False because reconnect threw.
+        assert coord._needs_resubscribe is False
+
+
+class TestRestoreSubscriptions:
+    """After reconnect + first successful poll, COV subs are rebuilt."""
+
+    def test_successful_poll_after_reconnect_calls_setup(self):
+        import asyncio
+
+        from unittest.mock import AsyncMock
+
+        coord = _make_coordinator(objects=[{"object_type": 0, "instance": 1}])
+        # Pretend an earlier setup already ran so first_run does not double-call.
+        coord._cov_subscriptions = {"0:1": "stale_key"}
+        coord._polled_objects = [{"object_type": 0, "instance": 1}]
+        coord._needs_resubscribe = True
+        coord.client.poll_objects = AsyncMock(
+            return_value={"0:1": {"presentValue": 23.5, "statusFlags": [False] * 4}}
+        )
+        # _setup_subscriptions would try to subscribe via the client; stub it
+        # so we can assert it was invoked without doing real BACnet I/O.
+        coord._setup_subscriptions = AsyncMock()
+
+        asyncio.run(coord._async_update_data())
+
+        # Restore path calls setup exactly once (first_run was False).
+        coord._setup_subscriptions.assert_awaited_once()
+        assert coord._needs_resubscribe is False
+        # _restore_subscriptions cleared the stale mapping before re-setup.
+        # (Setup itself is mocked, so it stays empty after the clear.)
+        assert coord._cov_subscriptions == {}
+
+    def test_no_resubscribe_without_reconnect(self):
+        """Normal successful polls must NOT rebuild subscriptions every cycle."""
+        import asyncio
+
+        from unittest.mock import AsyncMock
+
+        coord = _make_coordinator(objects=[{"object_type": 0, "instance": 1}])
+        coord._needs_resubscribe = False
+        coord.client.poll_objects = AsyncMock(
+            return_value={"0:1": {"presentValue": 23.5, "statusFlags": [False] * 4}}
+        )
+        # Stubbed so first_run setup also doesn't run real COV I/O.
+        called = {"count": 0}
+
+        async def fake_setup():
+            called["count"] += 1
+            coord._polled_objects = list(coord.objects)
+
+        coord._setup_subscriptions = fake_setup
+
+        asyncio.run(coord._async_update_data())
+
+        # first_run triggers setup exactly once; restore path did not.
+        assert called["count"] == 1

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -1,0 +1,393 @@
+"""
+Tests for platform entity property logic.
+
+Each entity is instantiated with a mock coordinator and config entry so
+network/HA plumbing is never exercised — only the property computation
+logic is verified.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.conftest import _make_coordinator, _make_entry
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _sensor(obj, data=None):
+    from custom_components.bacnet.sensor import BACnetSensor
+
+    coord = _make_coordinator(data or {})
+    return BACnetSensor(coord, _make_entry(), obj)
+
+
+def _binary_sensor(obj, data=None):
+    from custom_components.bacnet.binary_sensor import BACnetBinarySensor
+
+    coord = _make_coordinator(data or {})
+    return BACnetBinarySensor(coord, _make_entry(), obj)
+
+
+def _switch(obj, data=None):
+    from custom_components.bacnet.switch import BACnetSwitch
+
+    coord = _make_coordinator(data or {})
+    return BACnetSwitch(coord, _make_entry(), obj)
+
+
+def _number(obj, data=None):
+    from custom_components.bacnet.number import BACnetNumber
+
+    coord = _make_coordinator(data or {})
+    return BACnetNumber(coord, _make_entry(), obj)
+
+
+def _climate(obj, data=None):
+    from custom_components.bacnet.climate import BACnetClimate
+
+    coord = _make_coordinator(data or {})
+    return BACnetClimate(coord, _make_entry(), obj)
+
+
+# ---------------------------------------------------------------------------
+# BACnetSensor.native_value
+# ---------------------------------------------------------------------------
+
+
+class TestSensorNativeValue:
+    def test_analog_float(self):
+        obj = {
+            "object_type": 0,
+            "instance": 1,
+            "commandable": False,
+            "object_name": "T",
+        }
+        entity = _sensor(obj, {"0:1": {"presentValue": 23.456}})
+        assert entity.native_value == pytest.approx(23.46)
+
+    def test_analog_none_when_no_data(self):
+        obj = {
+            "object_type": 0,
+            "instance": 1,
+            "commandable": False,
+            "object_name": "T",
+        }
+        entity = _sensor(obj, {})
+        assert entity.native_value is None
+
+    def test_multi_state_int(self):
+        obj = {
+            "object_type": 13,
+            "instance": 1,
+            "commandable": False,
+            "object_name": "M",
+        }
+        entity = _sensor(obj, {"13:1": {"presentValue": 3}})
+        assert entity.native_value == 3
+
+    def test_analog_bad_value_returns_none(self):
+        obj = {
+            "object_type": 0,
+            "instance": 1,
+            "commandable": False,
+            "object_name": "T",
+        }
+        entity = _sensor(obj, {"0:1": {"presentValue": "not-a-number"}})
+        assert entity.native_value is None
+
+    def test_multi_state_bad_value_returns_str(self):
+        obj = {
+            "object_type": 13,
+            "instance": 1,
+            "commandable": False,
+            "object_name": "M",
+        }
+        entity = _sensor(obj, {"13:1": {"presentValue": "mode-active"}})
+        assert entity.native_value == "mode-active"
+
+
+# ---------------------------------------------------------------------------
+# BACnetBinarySensor.is_on
+# ---------------------------------------------------------------------------
+
+
+class TestBinarySensorIsOn:
+    def test_none_when_no_data(self):
+        obj = {
+            "object_type": 3,
+            "instance": 1,
+            "commandable": False,
+            "object_name": "B",
+        }
+        entity = _binary_sensor(obj, {})
+        assert entity.is_on is None
+
+    def test_active_string_is_true(self):
+        obj = {
+            "object_type": 3,
+            "instance": 1,
+            "commandable": False,
+            "object_name": "B",
+        }
+        entity = _binary_sensor(obj, {"3:1": {"presentValue": "active"}})
+        assert entity.is_on is True
+
+    def test_inactive_string_is_false(self):
+        obj = {
+            "object_type": 3,
+            "instance": 1,
+            "commandable": False,
+            "object_name": "B",
+        }
+        entity = _binary_sensor(obj, {"3:1": {"presentValue": "inactive"}})
+        assert entity.is_on is False
+
+    def test_int_one_is_true(self):
+        obj = {
+            "object_type": 3,
+            "instance": 1,
+            "commandable": False,
+            "object_name": "B",
+        }
+        entity = _binary_sensor(obj, {"3:1": {"presentValue": 1}})
+        assert entity.is_on is True
+
+    def test_int_zero_is_false(self):
+        obj = {
+            "object_type": 3,
+            "instance": 1,
+            "commandable": False,
+            "object_name": "B",
+        }
+        entity = _binary_sensor(obj, {"3:1": {"presentValue": 0}})
+        assert entity.is_on is False
+
+    def test_case_insensitive_string(self):
+        obj = {
+            "object_type": 3,
+            "instance": 1,
+            "commandable": False,
+            "object_name": "B",
+        }
+        entity = _binary_sensor(obj, {"3:1": {"presentValue": "ACTIVE"}})
+        assert entity.is_on is True
+
+
+# ---------------------------------------------------------------------------
+# BACnetSwitch.is_on
+# ---------------------------------------------------------------------------
+
+
+class TestSwitchIsOn:
+    def test_none_when_no_data(self):
+        obj = {"object_type": 4, "instance": 1, "commandable": True, "object_name": "S"}
+        entity = _switch(obj, {})
+        assert entity.is_on is None
+
+    def test_active_is_true(self):
+        obj = {"object_type": 4, "instance": 1, "commandable": True, "object_name": "S"}
+        entity = _switch(obj, {"4:1": {"presentValue": "active"}})
+        assert entity.is_on is True
+
+    def test_int_one_is_true(self):
+        obj = {"object_type": 4, "instance": 1, "commandable": True, "object_name": "S"}
+        entity = _switch(obj, {"4:1": {"presentValue": 1}})
+        assert entity.is_on is True
+
+    def test_int_zero_is_false(self):
+        obj = {"object_type": 4, "instance": 1, "commandable": True, "object_name": "S"}
+        entity = _switch(obj, {"4:1": {"presentValue": 0}})
+        assert entity.is_on is False
+
+
+# ---------------------------------------------------------------------------
+# BACnetNumber.native_value
+# ---------------------------------------------------------------------------
+
+
+class TestNumberNativeValue:
+    def test_float_value(self):
+        obj = {"object_type": 1, "instance": 1, "commandable": True, "object_name": "N"}
+        entity = _number(obj, {"1:1": {"presentValue": 42.5}})
+        assert entity.native_value == pytest.approx(42.5)
+
+    def test_none_when_missing(self):
+        obj = {"object_type": 1, "instance": 1, "commandable": True, "object_name": "N"}
+        entity = _number(obj, {})
+        assert entity.native_value is None
+
+    def test_int_converted_to_float(self):
+        obj = {"object_type": 1, "instance": 1, "commandable": True, "object_name": "N"}
+        entity = _number(obj, {"1:1": {"presentValue": 7}})
+        assert entity.native_value == 7.0
+        assert isinstance(entity.native_value, float)
+
+    def test_bad_value_returns_none(self):
+        obj = {"object_type": 1, "instance": 1, "commandable": True, "object_name": "N"}
+        entity = _number(obj, {"1:1": {"presentValue": "not-a-number"}})
+        assert entity.native_value is None
+
+    def test_multi_state_min_max(self):
+        from custom_components.bacnet.const import OBJECT_TYPE_MULTI_STATE_OUTPUT
+
+        obj = {
+            "object_type": OBJECT_TYPE_MULTI_STATE_OUTPUT,
+            "instance": 1,
+            "commandable": True,
+            "object_name": "MSO",
+        }
+        entity = _number(obj, {})
+        assert entity._attr_native_min_value == 1
+        assert entity._attr_native_max_value == 255
+        assert entity._attr_native_step == 1.0
+
+
+# ---------------------------------------------------------------------------
+# BACnetClimate.hvac_mode and current_temperature
+# ---------------------------------------------------------------------------
+
+
+class TestClimate:
+    def test_hvac_heat_when_value_present(self):
+        obj = {
+            "object_type": 2,
+            "instance": 1,
+            "commandable": True,
+            "object_name": "SP",
+        }
+        entity = _climate(obj, {"2:1": {"presentValue": 21.0}})
+        from custom_components.bacnet.climate import HVACMode
+
+        assert entity.hvac_mode == HVACMode.HEAT
+
+    def test_hvac_off_when_value_is_none(self):
+        obj = {
+            "object_type": 2,
+            "instance": 1,
+            "commandable": True,
+            "object_name": "SP",
+        }
+        entity = _climate(obj, {})
+        from custom_components.bacnet.climate import HVACMode
+
+        assert entity.hvac_mode == HVACMode.OFF
+
+    def test_current_temperature_rounded(self):
+        obj = {
+            "object_type": 2,
+            "instance": 1,
+            "commandable": True,
+            "object_name": "SP",
+        }
+        entity = _climate(obj, {"2:1": {"presentValue": 21.456}})
+        assert entity.current_temperature == pytest.approx(21.5)
+
+    def test_current_temperature_none_when_missing(self):
+        obj = {
+            "object_type": 2,
+            "instance": 1,
+            "commandable": True,
+            "object_name": "SP",
+        }
+        entity = _climate(obj, {})
+        assert entity.current_temperature is None
+
+    def test_temperature_unit_celsius_by_default(self):
+        obj = {
+            "object_type": 2,
+            "instance": 1,
+            "commandable": True,
+            "object_name": "SP",
+            "units": "degreesCelsius",
+        }
+        entity = _climate(obj, {})
+        assert (
+            "°C" in str(entity._attr_temperature_unit)
+            or entity._attr_temperature_unit is not None
+        )
+
+    def test_temperature_unit_fahrenheit(self):
+        obj = {
+            "object_type": 2,
+            "instance": 1,
+            "commandable": True,
+            "object_name": "SP",
+            "units": "degreesFahrenheit",
+        }
+        entity = _climate(obj, {})
+        assert entity._attr_min_temp == 40.0
+        assert entity._attr_max_temp == 104.0
+
+
+# ---------------------------------------------------------------------------
+# BACnetEntity.available and extra_state_attributes
+# ---------------------------------------------------------------------------
+
+
+class TestEntityBase:
+    def test_unavailable_when_no_data(self):
+        obj = {
+            "object_type": 0,
+            "instance": 1,
+            "commandable": False,
+            "object_name": "T",
+        }
+        entity = _sensor(obj, {})
+        assert entity.available is False
+
+    def test_available_when_data_present(self):
+        obj = {
+            "object_type": 0,
+            "instance": 1,
+            "commandable": False,
+            "object_name": "T",
+        }
+        entity = _sensor(obj, {"0:1": {"presentValue": 23.0}})
+        assert entity.available is True
+
+    def test_extra_attributes_include_bacnet_keys(self):
+        obj = {
+            "object_type": 0,
+            "instance": 1,
+            "commandable": False,
+            "object_name": "Room Temp",
+            "description": "Zone 1 temperature",
+            "units": "degreesCelsius",
+        }
+        entity = _sensor(
+            obj,
+            {
+                "0:1": {
+                    "presentValue": 22.0,
+                    "statusFlags": [False, False, False, False],
+                }
+            },
+        )
+        attrs = entity.extra_state_attributes
+        assert "bacnet_object_type" in attrs
+        assert "bacnet_instance" in attrs
+        assert attrs["bacnet_instance"] == 1
+        assert "bacnet_commandable" in attrs
+        assert attrs["bacnet_commandable"] is False
+        assert "bacnet_units" in attrs
+        assert "bacnet_description" in attrs
+        assert "bacnet_status_flags" in attrs
+        assert "bacnet_update_method" in attrs
+
+    def test_unique_id_uses_device_id(self):
+        obj = {
+            "object_type": 0,
+            "instance": 5,
+            "commandable": False,
+            "object_name": "T",
+        }
+        entry = _make_entry(device_id=99999)
+        coord = _make_coordinator({})
+        from custom_components.bacnet.sensor import BACnetSensor
+
+        entity = BACnetSensor(coord, entry, obj)
+        assert "99999" in entity._attr_unique_id
+        assert "bacnet" in entity._attr_unique_id

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,0 +1,38 @@
+"""Tests for helpers.mask_address."""
+
+from custom_components.bacnet.helpers import mask_address
+
+
+class TestMaskAddress:
+    def test_ipv4_no_port(self):
+        assert mask_address("192.168.1.100") == "192.x.x.100"
+
+    def test_ipv4_with_port(self):
+        assert mask_address("10.0.0.1:47808") == "10.x.x.1:47808"
+
+    def test_first_and_last_octet_preserved(self):
+        result = mask_address("172.16.254.1")
+        assert result.startswith("172.")
+        assert result.endswith(".1")
+        assert "x.x" in result
+
+    def test_middle_octets_masked(self):
+        result = mask_address("1.2.3.4")
+        assert "2" not in result or result == "1.x.x.4"  # 2 only hidden
+        assert result == "1.x.x.4"
+
+    def test_non_ipv4_passthrough(self):
+        assert mask_address("bacnet-device") == "bacnet-device"
+
+    def test_empty_string(self):
+        assert mask_address("") == "<none>"
+
+    def test_object_with_str(self):
+        class Addr:
+            def __str__(self):
+                return "10.1.2.3:47809"
+
+        assert mask_address(Addr()) == "10.x.x.3:47809"
+
+    def test_port_variants(self):
+        assert mask_address("192.168.0.50:1234") == "192.x.x.50:1234"

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,0 +1,182 @@
+"""Tests for __init__._domain_for_object and _get_platforms_in_use."""
+
+from __future__ import annotations
+
+import pytest
+
+from custom_components.bacnet.__init__ import _domain_for_object, _get_platforms_in_use
+from custom_components.bacnet.const import (
+    OBJECT_TYPE_ANALOG_INPUT,
+    OBJECT_TYPE_ANALOG_OUTPUT,
+    OBJECT_TYPE_ANALOG_VALUE,
+    OBJECT_TYPE_BINARY_INPUT,
+    OBJECT_TYPE_BINARY_OUTPUT,
+    OBJECT_TYPE_BINARY_VALUE,
+    OBJECT_TYPE_MULTI_STATE_INPUT,
+    OBJECT_TYPE_MULTI_STATE_OUTPUT,
+    OBJECT_TYPE_MULTI_STATE_VALUE,
+)
+
+
+# ---------------------------------------------------------------------------
+# _domain_for_object
+# ---------------------------------------------------------------------------
+
+
+class TestDomainForObject:
+    @pytest.mark.parametrize(
+        "obj_type, commandable, expected",
+        [
+            (OBJECT_TYPE_ANALOG_INPUT, False, "sensor"),
+            (OBJECT_TYPE_ANALOG_OUTPUT, True, "number"),
+            (OBJECT_TYPE_BINARY_INPUT, False, "binary_sensor"),
+            (OBJECT_TYPE_BINARY_OUTPUT, True, "switch"),
+            (OBJECT_TYPE_MULTI_STATE_INPUT, False, "sensor"),
+            (OBJECT_TYPE_MULTI_STATE_OUTPUT, True, "number"),
+            # Value types depend on commandable flag
+            (OBJECT_TYPE_ANALOG_VALUE, True, "number"),
+            (OBJECT_TYPE_ANALOG_VALUE, False, "sensor"),
+            (OBJECT_TYPE_BINARY_VALUE, True, "switch"),
+            (OBJECT_TYPE_BINARY_VALUE, False, "binary_sensor"),
+            (OBJECT_TYPE_MULTI_STATE_VALUE, True, "number"),
+            (OBJECT_TYPE_MULTI_STATE_VALUE, False, "sensor"),
+        ],
+    )
+    def test_defaults(self, obj_type, commandable, expected):
+        obj = {"object_type": obj_type, "instance": 1, "commandable": commandable}
+        assert _domain_for_object(obj, {}) == expected
+
+    def test_override_takes_precedence(self):
+        obj = {
+            "object_type": OBJECT_TYPE_BINARY_VALUE,
+            "instance": 7,
+            "commandable": False,
+        }
+        overrides = {"5:7": "climate"}
+        assert _domain_for_object(obj, overrides) == "climate"
+
+    def test_missing_commandable_flag_defaults_to_false(self):
+        obj = {"object_type": OBJECT_TYPE_BINARY_VALUE, "instance": 1}
+        assert _domain_for_object(obj, {}) == "binary_sensor"
+
+
+# ---------------------------------------------------------------------------
+# _get_platforms_in_use  (the A1 bug fix)
+# ---------------------------------------------------------------------------
+
+
+class TestGetPlatformsInUse:
+    def _platforms(self, objects, overrides=None):
+        result = _get_platforms_in_use(objects, overrides or {})
+        return {p.value for p in result}
+
+    def test_analog_input_needs_sensor(self):
+        obj = {
+            "object_type": OBJECT_TYPE_ANALOG_INPUT,
+            "instance": 1,
+            "commandable": False,
+        }
+        assert "sensor" in self._platforms([obj])
+
+    def test_binary_input_needs_binary_sensor(self):
+        obj = {
+            "object_type": OBJECT_TYPE_BINARY_INPUT,
+            "instance": 1,
+            "commandable": False,
+        }
+        assert "binary_sensor" in self._platforms([obj])
+
+    def test_commandable_bv_needs_switch(self):
+        obj = {
+            "object_type": OBJECT_TYPE_BINARY_VALUE,
+            "instance": 1,
+            "commandable": True,
+        }
+        assert "switch" in self._platforms([obj])
+
+    def test_non_commandable_bv_needs_binary_sensor_not_switch(self):
+        """A1 regression: non-commandable BV must land on binary_sensor, not switch."""
+        obj = {
+            "object_type": OBJECT_TYPE_BINARY_VALUE,
+            "instance": 1,
+            "commandable": False,
+        }
+        platforms = self._platforms([obj])
+        assert "binary_sensor" in platforms
+        assert "switch" not in platforms
+
+    def test_non_commandable_av_needs_sensor_not_number(self):
+        obj = {
+            "object_type": OBJECT_TYPE_ANALOG_VALUE,
+            "instance": 1,
+            "commandable": False,
+        }
+        platforms = self._platforms([obj])
+        assert "sensor" in platforms
+        assert "number" not in platforms
+
+    def test_commandable_av_needs_number(self):
+        obj = {
+            "object_type": OBJECT_TYPE_ANALOG_VALUE,
+            "instance": 1,
+            "commandable": True,
+        }
+        assert "number" in self._platforms([obj])
+
+    def test_mixed_objects_returns_correct_platforms(self):
+        objects = [
+            {
+                "object_type": OBJECT_TYPE_ANALOG_INPUT,
+                "instance": 1,
+                "commandable": False,
+            },
+            {
+                "object_type": OBJECT_TYPE_BINARY_VALUE,
+                "instance": 2,
+                "commandable": False,
+            },
+            {
+                "object_type": OBJECT_TYPE_ANALOG_OUTPUT,
+                "instance": 3,
+                "commandable": True,
+            },
+        ]
+        platforms = self._platforms(objects)
+        assert "sensor" in platforms
+        assert "binary_sensor" in platforms
+        assert "number" in platforms
+        assert "switch" not in platforms
+
+    def test_domain_override_respected(self):
+        obj = {
+            "object_type": OBJECT_TYPE_ANALOG_INPUT,
+            "instance": 5,
+            "commandable": False,
+        }
+        platforms = self._platforms([obj], {"0:5": "climate"})
+        assert "climate" in platforms
+
+    def test_empty_object_list(self):
+        assert _get_platforms_in_use([], {}) == []
+
+    def test_no_duplicate_platforms(self):
+        objects = [
+            {
+                "object_type": OBJECT_TYPE_ANALOG_INPUT,
+                "instance": 1,
+                "commandable": False,
+            },
+            {
+                "object_type": OBJECT_TYPE_ANALOG_INPUT,
+                "instance": 2,
+                "commandable": False,
+            },
+            {
+                "object_type": OBJECT_TYPE_ANALOG_VALUE,
+                "instance": 3,
+                "commandable": False,
+            },
+        ]
+        result = _get_platforms_in_use(objects, {})
+        platform_values = [p.value for p in result]
+        assert len(platform_values) == len(set(platform_values))


### PR DESCRIPTION
## Problem

After a network outage of 1–2 hours the integration stopped retrying the device and required a manual disable/enable to reconnect. Reported in #18.

## Root cause

Three independent failure modes all converged on `no auto-recovery`:

1. **Silent stale data** — `coordinator._async_update_data` swallowed every poll exception and returned stale data indefinitely. HA saw a clean return, so no error was surfaced, no backoff was applied, and entities froze on the last value. From the user side it looked like the integration had `stopped connecting`.
2. **BBMD TTL expiry** — Foreign-device registration TTL is 900 s (15 min). Outages longer than that cause the BBMD to drop the registration; `client.connect()` only registered once at setup, so polls kept timing out forever once the network returned.
3. **COV subscription death** — COV lifetime is 300 s (5 min). After expiry the `_cov_reader_task` exits and removes itself from `_cov_tasks`, but the coordinator's `_cov_subscriptions` mapping still held the stale sub key, so `is_cov_subscribed()` reported `True` and the polling fallback never kicked in.

## Fix

- **Surface failures:** track consecutive failed polls and raise `UpdateFailed` after `MAX_SILENT_FAILURES = 3` so HA surfaces the outage and applies its native retry backoff. A poll counts as failed when no object returned a non-`None` `presentValue` (BACpypes3 timeouts surface as `None`, not exceptions).
- **Reconnect stale client:** add `BACnetClient.reconnect()` (`disconnect()` + `connect()` with the stored BBMD params) and trigger it once when failures cross `RECONNECT_THRESHOLD = 10` (~5 min @ 30 s polling).
- **Restore COV subs:** after a successful poll post-reconnect, the coordinator rebuilds COV subscriptions so devices that support COV pick it back up.

## Behavior after fix

| Failures | Action |
|---|---|
| 1–2 | Keep stale data (avoid flapping on brief blips) |
| 3–9 | Raise `UpdateFailed` → HA shows `Failed` badge, polling continues with backoff |
| 10 | Reconnect underlying client once (re-registers with BBMD) |
| Next success | Reset counter + rebuild COV subscriptions |

## Tests

- `coordinator`: failure tracking, `UpdateFailed` raise at threshold, reconnect trigger (once per outage, error-tolerant), COV restore on first success, success resets counter
- `bacnet_client`: `reconnect()` uses stored BBMD params, defaults when never connected

Full suite: `141 passed`. `ruff check .` and `ruff format --check .` clean.

## Other changes

- `tests/` and `pyproject.toml` are now tracked (previously gitignored) so contributors can run the suite.
- `.gitignore` cleaned: removed dead rules (`TESTING.md`, `rl_*`, `BACnet virtual device/`), added AI-tooling patterns, added common junk (`*.log`, `*.bak`, `.env*`, etc.).
- Version bumped to 1.0.20.

Closes #18